### PR TITLE
fix: postdatail에서 한 게시글에 여러 개의 사진이 출력되도록 수정

### DIFF
--- a/app/src/main/java/bitcamp/carrot_thunder/post/dto/PostResponseDto.java
+++ b/app/src/main/java/bitcamp/carrot_thunder/post/dto/PostResponseDto.java
@@ -56,4 +56,8 @@ public class PostResponseDto {
             .attachedFilesPaths(post.getAttachedFiles())
             .build();
   }
+
+  public void setAttachedFiles(List<AttachedFile> attachedFilesPaths) {
+    this.attachedFilesPaths = attachedFilesPaths;
+  }
 }

--- a/app/src/main/java/bitcamp/carrot_thunder/post/service/DefaultPostService.java
+++ b/app/src/main/java/bitcamp/carrot_thunder/post/service/DefaultPostService.java
@@ -196,10 +196,17 @@ public class DefaultPostService implements PostService {
      * @param postId
      * @return
      */
-    public PostResponseDto getPost(Long postId, UserDetailsImpl userDetails)  {
-        Post post = (Post) postDao.findById(postId).orElseThrow(() -> NotFoundPostException.EXCEPTION );
-        return PostResponseDto.of(post);
+    @Override
+    public PostResponseDto getPost(Long postId, UserDetailsImpl userDetails) {
+        Post post = (Post) postDao.findById(postId).orElseThrow(() -> NotFoundPostException.EXCEPTION);
 
+        List<AttachedFile> attachedFiles = postDao.findImagesByPostId(postId);
+
+        // 이미지 정보를 PostResponseDto에 설정하여 반환합니다.
+        PostResponseDto postResponseDto = PostResponseDto.of(post);
+        postResponseDto.setAttachedFiles(attachedFiles);
+
+        return postResponseDto;
     }
 
 

--- a/app/src/main/resources/mapper/PostDao.xml
+++ b/app/src/main/resources/mapper/PostDao.xml
@@ -93,6 +93,17 @@
         a.id DESC
     </select>
 
+    <select id="findImagesByPostId" resultMap="attachedFileMap">
+        SELECT
+        id,
+        filepath,
+        article_id
+        FROM
+        tbl_file
+        WHERE
+        article_id = #{postId}
+    </select>
+
     <select id="getMyPosts" resultMap="articleMap">
         SELECT
         a.id,


### PR DESCRIPTION
프론트에서 게시글 상세보기 관련api를 날릴 시 사진 이미지가 1개만 출력이 되던것을 백엔드 코드에서 수정하였습니다.