### PR TITLE
feat:채팅방 나가기 구현

### DIFF
--- a/app/src/main/java/bitcamp/carrot_thunder/chatting/controller/ChattingController.java
+++ b/app/src/main/java/bitcamp/carrot_thunder/chatting/controller/ChattingController.java
@@ -152,4 +152,17 @@ public class ChattingController {
       return ResponseEntity.status(HttpStatus.NOT_FOUND).body("메시지를 찾을 수 없습니다.");
     }
   }
+
+  @PutMapping("/chatting/leaveRoom")
+  public ResponseEntity<String> leaveChatRoom(@RequestParam String roomId, @RequestParam int userId) {
+    int rowsAffected = chattingService.leaveChatRoom(roomId, userId);
+    System.out.println("------->" + rowsAffected);
+    if (rowsAffected > 0) {
+      // 채팅방 나가기에 성공한 경우
+      return ResponseEntity.ok("채팅방에서 나갔습니다.");
+    } else {
+      // 채팅방 나가기에 실패한 경우
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("채팅방 나가기에 실패했습니다.");
+    }
+  }
 }

--- a/app/src/main/java/bitcamp/carrot_thunder/chatting/model/dao/ChattingDAO.java
+++ b/app/src/main/java/bitcamp/carrot_thunder/chatting/model/dao/ChattingDAO.java
@@ -47,4 +47,6 @@ public interface ChattingDAO {
   ChatMessageVO getChatMessageById(@Param("messageId") int messageId);
 
   void updateChatMessage(ChatMessageVO message);
+
+  int leaveChatRoom(String roomId, int userId);
 }

--- a/app/src/main/java/bitcamp/carrot_thunder/chatting/service/ChattingService.java
+++ b/app/src/main/java/bitcamp/carrot_thunder/chatting/service/ChattingService.java
@@ -33,4 +33,6 @@ public interface ChattingService {
   ChatMessageVO getChatMessageById(int messageId);
 
   void updateChatMessage(ChatMessageVO content);
+
+  int leaveChatRoom(String roomId, int userId);
 }

--- a/app/src/main/java/bitcamp/carrot_thunder/chatting/service/DefaultChattingService.java
+++ b/app/src/main/java/bitcamp/carrot_thunder/chatting/service/DefaultChattingService.java
@@ -108,4 +108,10 @@ public class DefaultChattingService implements ChattingService {
       chattingDAO.updateChatMessage(existingMessage);
     }
   }
+
+  @Override
+  public int leaveChatRoom(String roomId, int userId) {
+    int rowsAffected = chattingDAO.leaveChatRoom(roomId, userId);
+    return rowsAffected;
+  }
 }

--- a/app/src/main/resources/mapper/ChattingDao.xml
+++ b/app/src/main/resources/mapper/ChattingDao.xml
@@ -206,4 +206,24 @@
         trans_content = ''
         WHERE message_id = #{messageId}
     </update>
+
+    <update id="updateChatRoom" parameterType="map">
+        UPDATE tbl_chat_room
+        SET user_id = #{userId}
+        WHERE room_id = #{roomId}
+    </update>
+
+
+    <update id="leaveChatRoom" parameterType="bitcamp.carrot_thunder.chatting.model.vo.ChatRoomVO">
+        UPDATE tbl_chat_room
+        SET seller_id = CASE
+        WHEN seller_id = #{userId} THEN -1
+        ELSE seller_id
+        END,
+        buyer_id = CASE
+        WHEN buyer_id = #{userId} THEN -1
+        ELSE buyer_id
+        END
+        WHERE room_id = #{roomId}
+    </update>
 </mapper>


### PR DESCRIPTION
tbl_user 테이블에 -1을 가진 알수없는 사용자 생성
나가기 api 호출 시 해당 유저의 id가 -1로 변경되어 나간 사람은 채팅목록에서 나간 채팅방이 보이지 않음
상대방은 해당 채팅방에서 알수없는 사용자로 뜸
현재 문제점 : 채팅방을 나간사람이 다시 입장 시 전의 채팅방으로 입장되는게 아닌 방을 다시 생성이됩니다