### PR TITLE
fix:채팅방이 이미 있을 시 채팅페이지로 가도록 수정

### DIFF
--- a/app/src/main/java/bitcamp/carrot_thunder/chatting/controller/ChattingController.java
+++ b/app/src/main/java/bitcamp/carrot_thunder/chatting/controller/ChattingController.java
@@ -83,11 +83,6 @@ public class ChattingController {
     Map<String, Object> result = new HashMap<>();
     String existingRoomId = chattingService.checkChatRoomExists(sellerId, currentUserId, postId, currentUserId);
     if (existingRoomId != null) {
-      ChatRoomVO chatRoom = new ChatRoomVO();
-      chatRoom.setUserId(currentUserId);
-      chatRoom.setBuyerId(currentUserId);
-      chatRoom.setRoomId(existingRoomId);
-      chattingService.rejoinChatRoom(chatRoom);
 
       ChatRoomVO existingRoom = chattingService.getChatRoomByPostIdAndUserId(postId, currentUserId);
       if (existingRoom != null && existingRoom.getRoomId().equals(existingRoomId)) {


### PR DESCRIPTION
createOrGetChatRoom 에서 전에 쓰던 rejoinroom 삭제하여 채팅방이 원래 있을 시 채팅페이지로 넘어가도록 수정